### PR TITLE
Moderate refactor

### DIFF
--- a/cogs/autoreply.py
+++ b/cogs/autoreply.py
@@ -132,7 +132,7 @@ class AutoReply(commands.Cog):
         if message.author.bot: return  # ignore all bots
         if message.content[0:12] == 'wb autoreply': return # ignore commands from this module
             
-        print('reading message for autoreply...')
+        print('Autoreply.py: reading message...')
         mentioned = []
 
         for i in message.mentions:

--- a/cogs/moderate.py
+++ b/cogs/moderate.py
@@ -1,12 +1,19 @@
+import sys
 import nextcord as discord
 import re
 from nextcord.ext import commands
 
-from internal import clear, constants
-
 class Moderate(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
+        
+    
+    async def reprimand_offender(self, user: discord.User, reason=''):
+        reprimand = self.bot.get_cog('Reprimand')
+        if reprimand is not None:
+            await reprimand.process_reprimand(user, reason)
+        else:
+            print('Could not reprimand offender, self.bot.get_cog(\'Reprimand\' is None.')
             
     @commands.Cog.listener("on_message")
     async def check_for_links(self, message):
@@ -15,24 +22,42 @@ class Moderate(commands.Cog):
         """
         if message.author.bot: return  # ignore all bots
         if message.channel.name != 'babe-wake-up': # ignore messages that aren't top-level and in babe-wake-up
-            print('Wrong channel, skipping message listener...\n')
+            print('Moderate.py: Wrong channel, skipping message listener...\n')
             return
-            
-        print('reading message for link...')
+        if message.thread is not None: 
+            print('Moderate.py: Thread created, skipping message listener...\n')
+            return # ignore messages that create threads
 
-        #regexLinkPattern = re.compile('((http|https)\:\/\/)?[a-zA-Z0-9\.\/\?\:@\-_=#]+\.([a-zA-Z]){2,6}([a-zA-Z0-9\.\&\/\?\:@\-_=#])*')
+        print('reading message for link...')
         link = re.search('((http|https)\:\/\/)[a-zA-Z0-9\.\/\?\:\-_=#][a-zA-Z0-9\.\/\?\:\-_=#]+', message.content)
-        #link = regexLinkPattern.search(message.content)
 
         if link is None: # act upon linkless message
-            
-            msg = await message.channel.send('' + message.author.mention + ' this message does not contain any links. If this message relates to a previously linked video, please consider making a threaded response to that video. This notification will self-destruct when you move your message.')
-            
-            # delete message after 2 minutes or if clear reaction is clicked, whichever comes first
-            await clear.clear_on_message_deleted(self.bot, msg, message)
+            msg = await message.reply('This message does not contain any link(s); if it relates to previously linked media, please consider making a threaded response to the original post. You have been reprimanded, and this notification will self-destruct when you move your message.')
+            await self.reprimand_offender(message.author, 'Moderator: #babe-wake-up rule violation.')
 
         else:
             print('message has link as expected')
+
+        
+    @commands.bot_has_permissions(read_message_history=True)
+    @commands.Cog.listener("on_message_delete")
+    async def clean_up_channel(self, deletedMessage: discord.Message):
+        """
+        This event checks every deleted message in the media channel for replies from itself to remove / clean up. 
+        """
+        if deletedMessage.author.bot: return  # ignore all bots
+        if deletedMessage.channel.name != 'babe-wake-up': # ignore messages that aren't top-level and in babe-wake-up
+            print('Moderate.py: Wrong channel, skipping message deleted listener...\n')
+            return
+        
+        # find the reply to the deleted message and clean it up
+        async for message in deletedMessage.channel.history(limit=sys.maxsize, before=None, after=deletedMessage.created_at):
+            if (message.author.id == self.bot.user.id) and (message.reference.message_id == deletedMessage.id):
+                await message.delete()
+                return 
+                # there will be only one message to remove
+                # it is likely to be the very next message in the history, so this method minimizes iteration
+    
 
 
 def setup(bot):

--- a/cogs/reprimand.py
+++ b/cogs/reprimand.py
@@ -17,12 +17,7 @@ class Reprimand(commands.Cog):
         if (user is None):  user = await self.bot.fetch_user(userId)
         return user.display_name
 
-    @commands.command()
-    async def reprimand(self, ctx, mandee: discord.User, *, reason=''):
-        """
-        Basic reprimand command, called with the name of the reprimandee. Record is made of the reprimand in the database.
-        """
-
+    async def process_reprimand(self, mandee: discord.User, reason=''):
         print('Starting reprimand')
         existing_entry = await self.find_user(str(mandee.id))
         pprint.pprint(existing_entry)
@@ -48,7 +43,15 @@ class Reprimand(commands.Cog):
         response = "" + mandee.display_name + ", you're reprimanded!"
         if reason != '': response += " Reason given: `" + reason + "`"
 
-        msg = await ctx.send(response)
+        return response
+
+    @commands.command()
+    async def reprimand(self, ctx, mandee: discord.User, *, reason=''):
+        """
+        Basic reprimand command, called with the name of the reprimandee. Record is made of the reprimand in the database.
+        """
+
+        msg = await ctx.send(self.process_reprimand(mandee, reason))
 
     @commands.command()
     async def reprimands(self, ctx, mandee:discord.User=None):
@@ -117,8 +120,8 @@ class Reprimand(commands.Cog):
                 await ctx.send("Here is the full reprimand log:", file=discord.File(file, "result.txt"))
 
 
-    @commands.command(name='reprimand clear')
     @commands.is_owner()
+    @commands.command()
     async def reprimand_clear(self, ctx, mandee: discord.User):
         """
         Admin: Clears a given user from the reprimand log. 

--- a/internal/clear.py
+++ b/internal/clear.py
@@ -27,18 +27,3 @@ async def author_clear(ctx: commands.Context, message: discord.Message):
     except asyncio.TimeoutError:
         await message.remove_reaction(constants.CLEAR_REACTION_EMOJI, message.author)
         return False
-
-async def clear_on_message_deleted(bot, message: discord.Message, originalMessage: discord.Message):
-    """
-    Waits to see if another message is deleted to delete the bot's message, or eventually deletes itself unprompted.
-    """
-
-    def check(deletedMessage):
-        return deletedMessage.id == originalMessage.id
-
-    try:
-        await bot.wait_for('message_delete', timeout=300.0, check=check)
-
-        await message.delete()
-    except asyncio.TimeoutError:
-        await message.delete()


### PR DESCRIPTION
Issue #21 
- Moved message delete listener outside of the on_message response to avoid spamming new listeners and requiring a timeout.
- Moderate now directly replies to offending messages, reprimands offenders, and only self-destructs when the offending message is deleted
- Moderate does not heckle on thread-creation, even if done on an offending message

- Fixed bug with reprimand_clear command, apparently cannot alias commands with a space in them
- Added clarity to some debug statements regarding listeners
- Removed unnecessary function in clear.py