### PR TITLE
Archive

### DIFF
--- a/cogs/archive.py
+++ b/cogs/archive.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+import urllib.request
+import sys
+import os
+from internal import constants
+import nextcord as discord
+from nextcord.ext import commands
+
+class Archive(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command()
+    @commands.bot_has_permissions(read_message_history=True)
+    @commands.is_owner()
+    async def archive(self, ctx):
+        """
+        Records entire history of this channel onto the bot's storage. All images are downloaded and the text log is saved.
+        """
+
+        msg = await ctx.send('Working to archive this channel...')
+
+        with open('../archives/' + ctx.channel.name + '.txt', 'w') as f:
+            async for message in ctx.channel.history(limit=sys.maxsize, oldest_first=True):
+                output = '[' + str(message.created_at) + ', ' + message.author.name + ']: '
+                if len(message.attachments) > 0:
+                    for attachment in message.attachments:
+                        output += '[ATTACHMENT] ' + attachment.url
+                else: output += message.content + '\n'
+                f.write(output)
+                print('wrote a message to ' + f.name)
+            f.close()
+
+        msg = await ctx.send('This channel has been saved!')
+
+def setup(bot):
+    bot.add_cog(Archive(bot))

--- a/cogs/archive.py
+++ b/cogs/archive.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-import urllib.request
 import sys
 import os
+import glob
 from internal import constants
 import nextcord as discord
 from nextcord.ext import commands
@@ -18,20 +18,38 @@ class Archive(commands.Cog):
         Records entire history of this channel onto the bot's storage. All images are downloaded and the text log is saved.
         """
 
-        msg = await ctx.send('Working to archive this channel...')
+        # msg = await ctx.send('Working to archive this channel...')
+        await ctx.message.add_reaction(constants.AFFIRMATIVE_REACTION_EMOJI)
+
+        # make dir for attachments if doesn't exist, otherwise wipe dir
+        if not os.path.exists('../archives/' + ctx.channel.name + '/'):
+            os.makedirs('../archives/' + ctx.channel.name + '/')
+        else:
+            files = glob.glob('../archives/' + ctx.channel.name + '/*')
+            for f in files:
+                os.remove(f)
 
         with open('../archives/' + ctx.channel.name + '.txt', 'w') as f:
             async for message in ctx.channel.history(limit=sys.maxsize, oldest_first=True):
                 output = '[' + str(message.created_at) + ', ' + message.author.name + ']: '
+
+                # process attachments, appropriately assign filetypes to images
+                # other filetypes can be recovered using the information from the content type added to the log
                 if len(message.attachments) > 0:
                     for attachment in message.attachments:
-                        output += '[ATTACHMENT] ' + attachment.url
+                        filetype = ''
+                        if 'image' in attachment.content_type: filetype = '.png'
+                        output += '[ATTACHMENT] ' + str(attachment.id) + ' content_type: ' + attachment.content_type + '\n'
+                        await attachment.save('../archives/' + ctx.channel.name + '/' +str(attachment.id) + filetype)
                 else: output += message.content + '\n'
+
+
                 f.write(output)
                 print('wrote a message to ' + f.name)
             f.close()
 
         msg = await ctx.send('This channel has been saved!')
+        await ctx.message.remove_reaction(constants.AFFIRMATIVE_REACTION_EMOJI, msg.author)
 
 def setup(bot):
     bot.add_cog(Archive(bot))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     networks:
       - mongo_default
     volumes:
-      - /mnt/nas-path/waambot-archives:/archives:rw
+      - /mnt/nas-data/waambot-archives:/archives:rw
 
 networks:
   mongo_default: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     restart: always
     networks:
       - mongo_default
+    volumes:
+      - /mnt/nas-path/waambot-archives:/archives:rw
 
 networks:
   mongo_default: 


### PR DESCRIPTION
Issue #25 
Able to archive text channels into a long text log. Attachments are saved into the archive as well, and the .png filetype is appended for images. Other types of media such as gifs may need special attention to reconstruct but the content_type information is stored in the text log. 
The bot is unable to differentiate between like-named channels from different servers (and server names lack the same filepath-safe validation that channel names have), so care should be taken to not overwrite another server's archive.